### PR TITLE
Update verification-metadata.xml

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -5,6 +5,10 @@
       <verify-signatures>false</verify-signatures>
       <trusted-artifacts>
          <trust group="net.runelite"/>
+         <trust group="net.runelite.gluegen"/>
+         <trust group="net.runelite.jocl"/>
+         <trust group="net.runelite.jogl"/>
+         <trust group="net.runelite.pushingpixels"/>
       </trusted-artifacts>
    </configuration>
    <components>


### PR DESCRIPTION
You need this for the plugin to build after 1.7.0. People have been asking for your plugin on the Discord.

Whenever you PR this, make sure to update your plugin on the hub. However it seems it currently does not build with the un-PR'ed changes you've made since then, possibly due to you adding new external dependencies which you need to add to this metadata as well.

Consider fixing that or PR'ing a branch with only this change.