### PR TITLE
Updates MenuEntry creation for Runelite API changes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.2.2'
+def runeLiteVersion = '1.8.7'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/loottable/controllers/LootTableController.java
+++ b/src/main/java/com/loottable/controllers/LootTableController.java
@@ -68,12 +68,13 @@ public class LootTableController {
                     if (combatLevel > 0) {
                         int widgetId = menuEntry.getParam1();
                         String monsterName = menuEntry.getTarget();
-                        final MenuEntry lootTableMenuEntry = new MenuEntry();
-                        lootTableMenuEntry.setOption(LOOT_TABLE_MENU_OPTION);
-                        lootTableMenuEntry.setTarget(monsterName);
-                        lootTableMenuEntry.setIdentifier(menuEntry.getIdentifier());
-                        lootTableMenuEntry.setParam1(widgetId);
-                        lootTableMenuEntry.setType(MenuAction.RUNELITE.getId());
+                        // Build and append our menu entry to the end of the list of entries.
+                        MenuEntry lootTableMenuEntry = client.createMenuEntry(menuEntries.length)
+                                .setOption(LOOT_TABLE_MENU_OPTION)
+                                .setTarget(monsterName)
+                                .setIdentifier(menuEntry.getIdentifier())
+                                .setParam1(widgetId)
+                                .setType(MenuAction.RUNELITE);
                         client.setMenuEntries(ArrayUtils.addAll(menuEntries, lootTableMenuEntry));
                     }
                 }


### PR DESCRIPTION
MenuEntry was made abstract and concrete instances are made through a builder, which takes a menu entry position as a parameter for initial creation.

This still requires a version bump, but I don't know what convention you want to follow for choosing version numbers.